### PR TITLE
Make it possible to hide selected sections on home view

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ The options available are:
 | `extra_cards`        | array of cards (optional  | unset                                                   | List of cards to show below room cards.                        |
 | `extra_views`        | array of views (optional) | unset                                                   | List of views to add to the dashboard.                         |
 | `domains`            | object (optional)         | All supported domains                                   | See [Supported domains](#supported-domains).                   |
+| `hide_chips`         | boolean (optional)        | false                                                   | Set to true to not show any chips                              |
+| `hide_persons`       | boolean (optional)        | false                                                   | Set to true to not show any persons                            |
+| `hide_greeting`      | boolean (optional)        | false                                                   | Set to true to not show greeting                               |
+| `hide_areas_title`   | boolean (optional)        | false                                                   | Set to true to not show areas title                            |
 
 #### Example
 

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -119,6 +119,10 @@
  * @property {Object[]} [quick_access_cards] List of cards to show between welcome card and rooms cards.
  * @property {Object[]} [extra_cards] List of cards to show below room cards.
  * @property {Object[]} [extra_views] List of views to add to the dashboard.
+ * @property {boolean} [hide_chips] Set to true to not show any chips
+ * @property {boolean} [hide_persons] Set to true to not show any persons
+ * @property {boolean} [hide_greeting] Set to true to not show greeting
+ * @property {boolean} [hide_areas_title] Set to true to not show areas title
  * @memberOf typedefs.generic
  */
 

--- a/src/views/HomeView.js
+++ b/src/views/HomeView.js
@@ -48,17 +48,24 @@ class HomeView extends AbstractView {
       this.#createAreaCards(),
     ]).then(([chips, personCards, areaCards]) => {
       const options       = Helper.strategyOptions;
-      const homeViewCards = [
-        {
+
+      const homeViewCards = [];
+      if (chips.length) {
+        homeViewCards.push({
           type: "custom:mushroom-chips-card",
           alignment: "center",
           chips: chips,
-        },
-        {
+        });
+      }
+
+      if (personCards.length) {
+        homeViewCards.push({
           type: "horizontal-stack",
           cards: personCards,
-        },
-        {
+        });
+      }
+      if (!Helper.strategyOptions.hide_greeting) {
+        homeViewCards.push({
           type: "custom:mushroom-template-card",
           primary: "{% set time = now().hour %} {% if (time >= 18) %} Good Evening, {{user}}! {% elif (time >= 12) %} Good Afternoon, {{user}}! {% elif (time >= 5) %} Good Morning, {{user}}! {% else %} Hello, {{user}}! {% endif %}",
           icon: "mdi:hand-wave",
@@ -72,9 +79,8 @@ class HomeView extends AbstractView {
           hold_action: {
             action: "none",
           },
-        },
-      ];
-
+        });
+      }
       // Add quick access cards.
       if (options.quick_access_cards) {
         homeViewCards.push(...options.quick_access_cards);
@@ -102,6 +108,9 @@ class HomeView extends AbstractView {
    */
   async #createChips() {
     const chips       = [];
+    if (Helper.strategyOptions.hide_chips) {
+      return chips;
+    }
     const chipOptions = Helper.strategyOptions.chips;
 
     // TODO: Get domains from config.
@@ -155,6 +164,9 @@ class HomeView extends AbstractView {
    */
   #createPersonCards() {
     const cards = [];
+    if (Helper.strategyOptions.hide_persons) {
+      return cards;
+    }
 
     import("../cards/PersonCard").then(personModule => {
       for (const person of Helper.entities.filter(entity => {
@@ -184,12 +196,13 @@ class HomeView extends AbstractView {
      *
      * @type {[{}]}
      */
-    const groupedCards = [
-      {
+    const groupedCards = [];
+    if (!Helper.strategyOptions.hide_areas_title) {
+      groupedCards.push({
         type: "custom:mushroom-title-card",
         title: "Areas",
-      },
-    ];
+      });
+    }
     let areaCards      = [];
 
     for (const [i, area] of Helper.areas.entries()) {


### PR DESCRIPTION
# What
Makes it possible to hide selected sections from home view. Yaml example:
```yaml
strategy:
  type: custom:mushroom-strategy
  options:
    hide_chips: true
    hide_persons: true
    hide_greeting: true
    hide_areas_title: true
views: []
```

# Why
If the user desires a cleaner look on the start page

# Example

<img width="861" alt="image" src="https://github.com/AalianKhan/mushroom-strategy/assets/26582898/37659880-ebaf-4440-a969-909c205b21fa">

```yaml
strategy:
  type: custom:mushroom-strategy
  options:
    hide_chips: true
    hide_persons: true
    hide_greeting: true
    areas:
      _:
        type: HaAreaCard
views: []
```