### PR TITLE
Use Mushroom Number Card for number entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ The following domains are supported and enabled by default:
 * media_player
 * sensor
 * binary_sensor
+* number
 * default (Miscellaneous)
 
 For these domains, the following options are supported:

--- a/README.md
+++ b/README.md
@@ -321,12 +321,12 @@ The following domains are supported and enabled by default:
 
 For these domains, the following options are supported:
 
-| Option         | type    | Description                                                                |
-|:---------------|:--------|:---------------------------------------------------------------------------|
-| `title`        | string  | Title of the domain in a view.                                             |
-| `showControls` | boolean | Weather to show controls int a view, to switch all entities of the domain. |
-| `hidden`       | boolean | Set to `true` to exclude the view from the dashboard.                      |
-| `order`        | number  | Ordering position of the domain entities in a view.                        |
+| Option         | type    | Description                                                               |
+|:---------------|:--------|:--------------------------------------------------------------------------|
+| `title`        | string  | Title of the domain in a view.                                            |
+| `showControls` | boolean | Weather to show controls in a view, to switch all entities of the domain. |
+| `hidden`       | boolean | Set to `true` to exclude the view from the dashboard.                     |
+| `order`        | number  | Ordering position of the domain entities in a view.                       |
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ For these domains, the following options are supported:
 |:---------------|:--------|:--------------------------------------------------------------------------|
 | `title`        | string  | Title of the domain in a view.                                            |
 | `showControls` | boolean | Weather to show controls in a view, to switch all entities of the domain. |
-| `hidden`       | boolean | Set to `true` to exclude the view from the dashboard.                     |
+| `hidden`       | boolean | Set to `true` to exclude the domain from the dashboard.                   |
 | `order`        | number  | Ordering position of the domain entities in a view.                       |
 
 #### Example

--- a/src/cards/NumberCard.js
+++ b/src/cards/NumberCard.js
@@ -1,0 +1,39 @@
+import {AbstractCard} from "./AbstractCard";
+
+/**
+ * Number Card Class
+ *
+ * Used to create a card for controlling an entity of the number domain.
+ *
+ * @class
+ * @extends AbstractCard
+ */
+class NumberCard extends AbstractCard {
+  /**
+   * Default options of the card.
+   *
+   * @type {numberCardOptions}
+   * @private
+   */
+  #defaultOptions = {
+    type: "custom:mushroom-number-card",
+    icon: undefined,
+  };
+
+  /**
+   * Class constructor.
+   *
+   * @param {hassEntity} entity The hass entity to create a card for.
+   * @param {numberCardOptions} [options={}] Options for the card.
+   * @throws {Error} If the Helper module isn't initialized.
+   */
+  constructor(entity, options = {}) {
+    super(entity);
+    this.mergeOptions(
+        this.#defaultOptions,
+        options,
+    );
+  }
+}
+
+export {NumberCard};

--- a/src/cards/NumberCard.js
+++ b/src/cards/NumberCard.js
@@ -29,10 +29,8 @@ class NumberCard extends AbstractCard {
    */
   constructor(entity, options = {}) {
     super(entity);
-    this.mergeOptions(
-        this.#defaultOptions,
-        options,
-    );
+
+    this.mergeOptions(this.#defaultOptions, options);
   }
 }
 

--- a/src/cards/typedefs.js
+++ b/src/cards/typedefs.js
@@ -61,6 +61,11 @@
  */
 
 /**
+ * @typedef {abstractOptions & Object} numberCardOptions Number Card options.
+ * @memberOf typedefs.cards
+ */
+
+/**
  * @typedef {abstractOptions & Object} switchCardOptions Switch Card options.
  * @property {{tap_action: switchTapAction}} [action] Home assistant action to perform on tap.
  * @memberOf typedefs.cards

--- a/src/optionDefaults.js
+++ b/src/optionDefaults.js
@@ -111,5 +111,10 @@ export const optionDefaults = {
       showControls: false,
       hidden: false,
     },
+    number: {
+      title: "Numbers",
+      showControls: false,
+      hidden: false,
+    },
   }
 }

--- a/src/optionDefaults.js
+++ b/src/optionDefaults.js
@@ -117,4 +117,4 @@ export const optionDefaults = {
       hidden: false,
     },
   }
-}
+};


### PR DESCRIPTION
Support number entities by using the Mushroom Number Card.

Before:
<img width="553" alt="image" src="https://github.com/AalianKhan/mushroom-strategy/assets/26582898/19f82002-8f33-4f1a-b972-1c9f7d9aef0d">

After:
<img width="553" alt="image" src="https://github.com/AalianKhan/mushroom-strategy/assets/26582898/b3da4b0b-5be1-452a-9bb7-b4d782349173">
