### PR TITLE
Documentation fix: none of the options for hiding sections in the homeView are correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,11 +355,11 @@ Home View options will let you configure the Home View.
 #### hidden
 
 The following elements are supported:
-* Chips
-* Persons
-* Greeting
-* AreaTitle
-* Areas
+* chips
+* persons
+* greeting
+* areasTitle
+* areas
 
 #### Example
 
@@ -369,8 +369,8 @@ strategy:
   options:
     homeView:
       hidden:
-        - Greeting
-        - AreaTitle
+        - greeting
+        - areasTitle
 views: []
 ```
 


### PR DESCRIPTION
The code for hiding sections in the home view is case sensitive, so none of the options in the Readme worked. Also, the option for the areas title was missing an 's'.