### PR TITLE
Add color temperature button to light card

### DIFF
--- a/src/cards/LightCard.js
+++ b/src/cards/LightCard.js
@@ -21,6 +21,7 @@ class LightCard extends AbstractCard {
     show_brightness_control: true,
     show_color_control: true,
     use_light_color: true,
+    show_color_temp_control: true,
     double_tap_action: {
       target: {
         entity_id: undefined,


### PR DESCRIPTION
This adds the button for the color temperature to the light card as the default.