### PR TITLE
Fix views not loading when using card_options

### DIFF
--- a/src/views/AbstractView.ts
+++ b/src/views/AbstractView.ts
@@ -149,7 +149,7 @@ abstract class AbstractView {
         entity =>
           entity.entity_id.startsWith(domain + ".")
           && !entity.hidden_by
-          && !Helper.strategyOptions.card_options?.entity_id?.hidden
+          && !Helper.strategyOptions.card_options?.[entity.entity_id]?.hidden
       ).map(entity => entity.entity_id),
     };
   }

--- a/src/views/AbstractView.ts
+++ b/src/views/AbstractView.ts
@@ -149,7 +149,7 @@ abstract class AbstractView {
         entity =>
           entity.entity_id.startsWith(domain + ".")
           && !entity.hidden_by
-          && !Helper.strategyOptions.card_options?.entity_id.hidden
+          && !Helper.strategyOptions.card_options?.entity_id?.hidden
       ).map(entity => entity.entity_id),
     };
   }


### PR DESCRIPTION
When using card_options with v2.0, it fails to create the views when card_options is defined, because it tries to access a non-existing entity_id.