### PR TITLE
Add device subviews

### DIFF
--- a/src/mushroom-strategy.ts
+++ b/src/mushroom-strategy.ts
@@ -7,6 +7,8 @@ import {StackCardConfig} from "./types/homeassistant/lovelace/cards/types";
 import {EntityCardConfig} from "./types/lovelace-mushroom/cards/entity-card-config";
 import {HassServiceTarget} from "home-assistant-js-websocket";
 import StrategyArea = generic.StrategyArea;
+import {DeviceRegistryEntry} from "./types/homeassistant/data/device_registry";
+import DeviceOptions = generic.DeviceOptions;
 
 /**
  * Mushroom Dashboard Strategy.<br>
@@ -70,6 +72,26 @@ class MushroomStrategy extends HTMLTemplateElement {
       }
     }
 
+    // Create subviews for each device with config in devices section.
+    const devicesWithSubviews = Helper.strategyOptions.devices ?? {};
+    const customCardConfig = Helper.strategyOptions.card_options ?? {};
+
+    for (let device of Helper.devices) {
+      if (!customCardConfig[device.id]?.hidden && devicesWithSubviews[device.id] !== null) {
+        views.push({
+          title: device.name_by_user ?? device.name ?? "device",
+          path: device.id,
+          subview: true,
+          strategy: {
+            type: "custom:mushroom-strategy",
+            options: {
+              device,
+            },
+          },
+        });
+      }
+    }
+
     // Add custom views.
     if (Helper.strategyOptions.extra_views) {
       views.push(...Helper.strategyOptions.extra_views);
@@ -91,8 +113,241 @@ class MushroomStrategy extends HTMLTemplateElement {
    */
   static async generateView(info: generic.ViewInfo): Promise<LovelaceViewConfig> {
     const exposedDomainIds = Helper.getExposedDomainIds();
+
+    if (generic.isViewInfoArea(info)) {
+      return await this.generateAreaView(info, exposedDomainIds);
+    } else if (generic.isViewInfoDevice(info)) {
+      return await this.generateDeviceView(info, exposedDomainIds);
+    }
+
+    // Return empty view.
+    return {
+      cards: [],
+    };
+  }
+
+  /**
+   * Generate a device view.
+   *
+   * Called when opening a device subview.
+   *
+   * @param {generic.ViewInfoDevice} info The view's strategy information object enriched with device options.
+   * @return {Promise<LovelaceViewConfig>}
+   */
+  private static async generateDeviceView(info: generic.ViewInfoGeneric<DeviceOptions>, exposedDomainIds: string[]): Promise<LovelaceViewConfig> {
+
+    const device = info.view.strategy?.options?.device ?? {} as DeviceRegistryEntry;
+    const deviceId = device.id;
+    const viewCards: LovelaceCardConfig[] = [];
+    const devicesWithSubviews = Helper.strategyOptions.devices ?? {};
+    const exposedEntityIds = devicesWithSubviews[deviceId].exposed_entity_ids ?? [];
+
+    // Set the target for controller cards to the current area.
+    let target: HassServiceTarget = {
+      device_id: [deviceId],
+    };
+
+    // Create cards for each domain.
+    for (const domain of exposedDomainIds) {
+      if (domain === "default") {
+        continue;
+      }
+
+      const className = Helper.sanitizeClassName(domain + "Card");
+
+      let domainCards = [];
+
+      try {
+        domainCards = await import(`./cards/${className}`).then(cardModule => {
+          let domainCards = [];
+          const entities = Helper.getEntitiesForDevice(deviceId, domain);
+          let configEntityHidden =
+                Helper.strategyOptions.domains[domain ?? "_"].hide_config_entities
+                || Helper.strategyOptions.domains["_"].hide_config_entities;
+          if (entities.length) {
+            // Create a Controller card for the current domain.
+            const titleCard = new ControllerCard(
+              target,
+              Helper.strategyOptions.domains[domain],
+            ).createCard();
+
+            if (domain === "sensor") {
+              // Create a card for each entity-sensor of the current area.
+              const sensorStates = Helper.getStateEntitiesForDevice(deviceId, "sensor");
+              const sensorCards: EntityCardConfig[] = [];
+
+              for (const sensor of entities) {
+                // Find the state of the current sensor.
+                const sensorState = sensorStates.find(state => state.entity_id === sensor.entity_id);
+                let cardOptions = Helper.strategyOptions.card_options?.[sensor.entity_id];
+                let deviceOptions = Helper.strategyOptions.card_options?.[sensor.device_id ?? "null"];
+
+                if (!cardOptions?.hidden && !deviceOptions?.hidden) {
+                  if (!exposedEntityIds.includes(sensor.entity_id)) {
+                    if (sensorState?.attributes.unit_of_measurement) {
+                      cardOptions = {
+                        ...{
+                          type: "custom:mini-graph-card",
+                          entities: [sensor.entity_id],
+                        },
+                        ...cardOptions,
+                      };
+                    }
+
+                    sensorCards.push(new SensorCard(sensor, cardOptions).getCard());
+                  }
+                }
+              }
+
+              if (sensorCards.length) {
+                domainCards.push({
+                  type: "vertical-stack",
+                  cards: sensorCards,
+                });
+
+                domainCards.unshift(titleCard);
+              }
+
+              return domainCards;
+            }
+
+            // Create a card for each other domain-entity of the current area.
+            for (const entity of entities) {
+              let deviceOptions;
+              let cardOptions = Helper.strategyOptions.card_options?.[entity.entity_id];
+
+              if (entity.device_id) {
+                deviceOptions = Helper.strategyOptions.card_options?.[entity.device_id];
+              }
+
+              if (exposedEntityIds.includes(entity.entity_id)) {
+                continue;
+              }
+
+              // Don't include the entity if hidden in the strategy options.
+              if (cardOptions?.hidden || deviceOptions?.hidden) {
+                continue;
+              }
+
+              // Don't include the config-entity if hidden in the strategy options.
+              if (entity.entity_category === "config" && configEntityHidden) {
+                continue;
+              }
+
+              domainCards.push(new cardModule[className](entity, cardOptions).getCard());
+            }
+
+            if (domain === "binary_sensor") {
+              // Horizontally group every two binary sensor cards.
+              const horizontalCards = [];
+
+              for (let i = 0; i < domainCards.length; i += 2) {
+                horizontalCards.push({
+                  type: "horizontal-stack",
+                  cards: domainCards.slice(i, i + 2),
+                });
+              }
+
+              domainCards = horizontalCards;
+            }
+
+            if (domainCards.length) {
+              domainCards.unshift(titleCard);
+            }
+          }
+
+          return domainCards;
+        });
+      } catch (e) {
+        Helper.logError("An error occurred while creating the domain cards!", e);
+      }
+
+      if (domainCards.length) {
+        viewCards.push({
+          type: "vertical-stack",
+          cards: domainCards,
+        });
+      }
+    }
+
+    if (!Helper.strategyOptions.domains.default.hidden) {
+
+      // Collect the remaining entities of which all conditions below are met:
+      // 1. The entity is not hidden.
+      // 2. The entity's domain isn't exposed (entities of exposed domains are already included).
+      // 3. The entity is linked to a device which is linked to the current area,
+      //    or the entity itself is linked to the current area.
+      const miscellaneousEntities = Helper.entities.filter((entity) => {
+        const entityLinked = entity.device_id === deviceId;
+        const entityUnhidden = entity.hidden_by === null && entity.disabled_by === null;
+        const domainExposed = exposedDomainIds.includes(entity.entity_id.split(".", 1)[0]);
+
+        return entityUnhidden && !domainExposed && entityLinked;
+      });
+
+      // Create a column of miscellaneous entity cards.
+      if (miscellaneousEntities.length) {
+        let miscellaneousCards: (StackCardConfig | EntityCardConfig)[] = [];
+
+        try {
+          miscellaneousCards = await import("./cards/MiscellaneousCard").then(cardModule => {
+            const miscellaneousCards: (StackCardConfig | EntityCardConfig)[] = [
+              new ControllerCard(target, Helper.strategyOptions.domains.default).createCard(),
+            ];
+
+            for (const entity of miscellaneousEntities) {
+              let cardOptions = Helper.strategyOptions.card_options?.[entity.entity_id];
+              let deviceOptions = Helper.strategyOptions.card_options?.[entity.device_id ?? "null"];
+
+              // Don't include the entity if hidden in the strategy options.
+              if (cardOptions?.hidden || deviceOptions?.hidden) {
+                continue;
+              }
+
+              if (exposedEntityIds.includes(entity.entity_id)) {
+                continue;
+              }
+
+              // Don't include the config-entity if hidden in the strategy options
+              if (entity.entity_category === "config" && Helper.strategyOptions.domains["_"].hide_config_entities) {
+                continue;
+              }
+
+              miscellaneousCards.push(new cardModule.MiscellaneousCard(entity, cardOptions).getCard());
+            }
+
+            return miscellaneousCards;
+          });
+        } catch (e) {
+          Helper.logError("An error occurred while creating the domain cards!", e);
+        }
+
+        viewCards.push({
+          type: "vertical-stack",
+          cards: miscellaneousCards,
+        });
+      }
+    }
+
+    // Return cards.
+    return {
+      cards: viewCards,
+    };
+  }
+
+  /**
+   * Generate an area view.
+   *
+   * Called when opening an area subview.
+   *
+   * @param {generic.ViewInfoArea} info The view's strategy information object enriched with area options.
+   * @return {Promise<LovelaceViewConfig>}
+   */
+  private static async generateAreaView(info: generic.ViewInfoArea, exposedDomainIds: string[]): Promise<LovelaceViewConfig> {
+
     const area = info.view.strategy?.options?.area ?? {} as StrategyArea;
     const viewCards: LovelaceCardConfig[] = [...(area.extra_cards ?? [])];
+    const devicesWithSubviews = Helper.strategyOptions.devices ?? {};
 
     // Set the target for controller cards to the current area.
     let target: HassServiceTarget = {
@@ -143,17 +398,30 @@ class MushroomStrategy extends HTMLTemplateElement {
                 let deviceOptions = Helper.strategyOptions.card_options?.[sensor.device_id ?? "null"];
 
                 if (!cardOptions?.hidden && !deviceOptions?.hidden) {
-                  if (sensorState?.attributes.unit_of_measurement) {
-                    cardOptions = {
-                      ...{
-                        type: "custom:mini-graph-card",
-                        entities: [sensor.entity_id],
-                      },
-                      ...cardOptions,
-                    };
-                  }
+                  if (sensor.device_id === null || !(sensor.device_id in devicesWithSubviews) || sensor.entity_id in devicesWithSubviews[sensor.device_id]?.exposed_entity_ids) {
+                    if (sensorState?.attributes.unit_of_measurement) {
+                      cardOptions = {
+                        ...{
+                          type: "custom:mini-graph-card",
+                          entities: [sensor.entity_id],
+                        },
+                        ...cardOptions,
+                      };
+                    }
 
-                  sensorCards.push(new SensorCard(sensor, cardOptions).getCard());
+                    if (sensor.device_id !== null && sensor.device_id in devicesWithSubviews && devicesWithSubviews[sensor.device_id]?.exposed_entity_ids.includes(sensor.entity_id)) {
+                      //overwrite hold action to point to device subview
+                      if (cardOptions) {
+                        cardOptions.hold_action = this.getHoldActionConfigForDeviceWithSubview(sensor.device_id);
+                      } else {
+                        cardOptions = {
+                          hold_action: this.getHoldActionConfigForDeviceWithSubview(sensor.device_id)
+                        }
+                      }
+                    }
+
+                    sensorCards.push(new SensorCard(sensor, cardOptions).getCard());
+                  }
                 }
               }
 
@@ -176,6 +444,21 @@ class MushroomStrategy extends HTMLTemplateElement {
 
               if (entity.device_id) {
                 deviceOptions = Helper.strategyOptions.card_options?.[entity.device_id];
+              }
+
+              if (entity.device_id !== null && entity.device_id in devicesWithSubviews) {
+                if (!devicesWithSubviews[entity.device_id]?.exposed_entity_ids.includes(entity.entity_id)) {
+                  continue;
+                } else {
+                  //overwrite hold action to point to device subview
+                  if (cardOptions) {
+                    cardOptions.hold_action = this.getHoldActionConfigForDeviceWithSubview(entity.device_id);
+                  } else {
+                    cardOptions = {
+                      hold_action: this.getHoldActionConfigForDeviceWithSubview(entity.device_id)
+                    }
+                  }
+                }
               }
 
               // Don't include the entity if hidden in the strategy options.
@@ -262,6 +545,22 @@ class MushroomStrategy extends HTMLTemplateElement {
                 continue;
               }
 
+              if (entity.device_id !== null && entity.device_id in devicesWithSubviews) {
+
+                if (!devicesWithSubviews[entity.device_id]?.exposed_entity_ids.includes(entity.entity_id)) {
+                  continue;
+                } else {
+                  //overwrite hold action to point to device subview
+                  if (cardOptions) {
+                    cardOptions.hold_action = this.getHoldActionConfigForDeviceWithSubview(entity.device_id);
+                  } else {
+                    cardOptions = {
+                      hold_action: this.getHoldActionConfigForDeviceWithSubview(entity.device_id)
+                    }
+                  }
+                }
+              }
+
               // Don't include the config-entity if hidden in the strategy options
               if (entity.entity_category === "config" && Helper.strategyOptions.domains["_"].hide_config_entities) {
                 continue;
@@ -287,6 +586,14 @@ class MushroomStrategy extends HTMLTemplateElement {
     return {
       cards: viewCards,
     };
+  }
+
+  private static getHoldActionConfigForDeviceWithSubview(device_id: string) {
+    const deviceHoldAction = {
+      action: "navigate" as const,
+      navigation_path: device_id,
+    }
+    return deviceHoldAction;
   }
 }
 


### PR DESCRIPTION
Add support for device subviews. User can add subviews for selected devices by specifying them in configuration. For such devices only specified entity cards are displayed in Area subview, other cards are accessible on newly added device subview.

Motivation:
- avoiding clutter on area subviews
- hiding rarely used functionalities (z-wave pings, obscure options, power meters)