### PR TITLE
Fix incorrect count of climate entities

### DIFF
--- a/src/Helper.ts
+++ b/src/Helper.ts
@@ -214,13 +214,12 @@ class Helper {
    * States are compared against a given value by a given operator.
    *
    * @param {string} domain The domain of the entities.
-   * @param {string} operator The Comparison operator between state and value.
-   * @param {string} value The value to which the state is compared against.
+   * @param {generic.EntityCountFilter[]} criteria Zero or more filters used to constrain the results.
    *
    * @return {string} The template string.
    * @static
    */
-  static getCountTemplate(domain: string, operator: string, value: string): string {
+  static getCountTemplate(domain: string, criteria: generic.EntityCountFilter[]): string {
     // noinspection JSMismatchedCollectionQueryUpdate (False positive per 17-04-2023)
     /**
      * Array of entity state-entries, filtered by domain.
@@ -229,11 +228,14 @@ class Helper {
      * a template.
      * E.g. "states['light.kitchen']"
      *
+     * Entities are filtered/selected by applying each specified criteria, in series.
+     *
      * The array excludes hidden and disabled entities.
      *
      * @type {string[]}
      */
     const states: string[] = [];
+    let filter_statement: string = "";
 
     if (!this.isInitialized()) {
       console.warn("Helper class should be initialized before calling this method!");
@@ -258,8 +260,10 @@ class Helper {
 
       states.push(...newStates);
     }
-
-    return `{% set entities = [${states}] %} {{ entities | selectattr('state','${operator}','${value}') | list | count }}`;
+    for (const each of criteria) {
+      filter_statement += ` | selectattr('state','${each.operator}','${each.value}')`;
+    }
+    return `{% set entities = [${states}] %} {{ entities ${filter_statement} | list | count }}`;
   }
 
   /**

--- a/src/chips/ClimateChip.ts
+++ b/src/chips/ClimateChip.ts
@@ -22,7 +22,7 @@ class ClimateChip extends AbstractChip {
     type: "template",
     icon: "mdi:thermostat",
     icon_color: "orange",
-    content: Helper.getCountTemplate("climate", "ne", "off"),
+    content: Helper.getCountTemplate("climate", [{operator: "ne", value: "off"}]),
     tap_action: {
       action: "none",
     },

--- a/src/chips/ClimateChip.ts
+++ b/src/chips/ClimateChip.ts
@@ -22,7 +22,7 @@ class ClimateChip extends AbstractChip {
     type: "template",
     icon: "mdi:thermostat",
     icon_color: "orange",
-    content: Helper.getCountTemplate("climate", [{operator: "ne", value: "off"}]),
+    content: Helper.getCountTemplate("climate", [{operator: "ne", value: "off"}, {operator: "ne", value: "unavailable"}]),
     tap_action: {
       action: "none",
     },

--- a/src/chips/CoverChip.ts
+++ b/src/chips/CoverChip.ts
@@ -22,7 +22,7 @@ class CoverChip extends AbstractChip {
     type: "template",
     icon: "mdi:window-open",
     icon_color: "cyan",
-    content: Helper.getCountTemplate("cover", "eq", "open"),
+    content: Helper.getCountTemplate("cover", [{operator: "eq", value: "open"}]),
     tap_action: {
       action: "none",
     },

--- a/src/chips/FanChip.ts
+++ b/src/chips/FanChip.ts
@@ -22,7 +22,7 @@ class FanChip extends AbstractChip {
     type: "template",
     icon: "mdi:fan",
     icon_color: "green",
-    content: Helper.getCountTemplate("fan", "eq", "on"),
+    content: Helper.getCountTemplate("fan", [{operator: "eq", value: "on"}]),
     tap_action: {
       action: "call-service",
       service: "fan.turn_off",

--- a/src/chips/LightChip.ts
+++ b/src/chips/LightChip.ts
@@ -22,7 +22,7 @@ class LightChip extends AbstractChip {
     type: "template",
     icon: "mdi:lightbulb-group",
     icon_color: "amber",
-    content: Helper.getCountTemplate("light", "eq", "on"),
+    content: Helper.getCountTemplate("light", [{operator: "eq", value: "on"}]),
     tap_action: {
       action: "call-service",
       service: "light.turn_off",

--- a/src/chips/SwitchChip.ts
+++ b/src/chips/SwitchChip.ts
@@ -22,7 +22,7 @@ class SwitchChip extends AbstractChip {
     type: "template",
     icon: "mdi:dip-switch",
     icon_color: "blue",
-    content: Helper.getCountTemplate("switch", "eq", "on"),
+    content: Helper.getCountTemplate("switch", [{operator: "eq", value: "on"}]),
     tap_action: {
       action: "call-service",
       service: "switch.turn_off",

--- a/src/types/strategy/generic.ts
+++ b/src/types/strategy/generic.ts
@@ -196,6 +196,17 @@ export namespace generic {
   }
 
   /**
+   * Entity Count Filter.
+   *
+   * @property {string} operator - Jinja2 selectattr filter operation name (eq, ne, ...)
+   * @property {string} value - Entity state value to filter upon
+   */
+    export interface EntityCountFilter {
+      operator: string;
+      value: string;
+  }
+
+  /**
    * Checks if the given object is an instance of CallServiceActionConfig.
    *
    * @param {any} obj - The object to be checked.

--- a/src/views/CameraView.ts
+++ b/src/views/CameraView.ts
@@ -47,7 +47,7 @@ class CameraView extends AbstractView {
    */
   #viewControllerCardConfig: cards.ControllerCardOptions = {
     title: "All Cameras",
-    subtitle: Helper.getCountTemplate(CameraView.#domain, "ne", "off") + " cameras on",
+    subtitle: Helper.getCountTemplate(CameraView.#domain, [{operator: "ne", value: "off"}]) + " cameras on",
   };
 
   /**

--- a/src/views/ClimateView.ts
+++ b/src/views/ClimateView.ts
@@ -47,7 +47,7 @@ class ClimateView extends AbstractView {
    */
   #viewControllerCardConfig: cards.ControllerCardOptions = {
     title: "All Climates",
-    subtitle: Helper.getCountTemplate(ClimateView.#domain, [{operator: "ne", value: "off"}]) + " climates on",
+    subtitle: Helper.getCountTemplate(ClimateView.#domain, [{operator: "ne", value: "off"}, {operator: "ne", value: "unavailable"}]) + " climates on",
   };
 
   /**

--- a/src/views/ClimateView.ts
+++ b/src/views/ClimateView.ts
@@ -47,7 +47,7 @@ class ClimateView extends AbstractView {
    */
   #viewControllerCardConfig: cards.ControllerCardOptions = {
     title: "All Climates",
-    subtitle: Helper.getCountTemplate(ClimateView.#domain, "ne", "off") + " climates on",
+    subtitle: Helper.getCountTemplate(ClimateView.#domain, [{operator: "ne", value: "off"}]) + " climates on",
   };
 
   /**

--- a/src/views/CoverView.ts
+++ b/src/views/CoverView.ts
@@ -50,7 +50,7 @@ class CoverView extends AbstractView {
    */
   #viewControllerCardConfig: cards.ControllerCardOptions = {
     title: "All Covers",
-    subtitle: Helper.getCountTemplate(CoverView.#domain, "eq", "open") + " covers open",
+    subtitle: Helper.getCountTemplate(CoverView.#domain, [{operator: "eq", value: "open"}]) + " covers open",
   };
 
   /**

--- a/src/views/FanView.ts
+++ b/src/views/FanView.ts
@@ -50,7 +50,7 @@ class FanView extends AbstractView {
    */
   #viewControllerCardConfig: cards.ControllerCardOptions = {
     title: "All Fans",
-    subtitle: Helper.getCountTemplate(FanView.#domain, "eq", "on") + " fans on",
+    subtitle: Helper.getCountTemplate(FanView.#domain, [{operator: "eq", value: "on"}]) + " fans on",
   };
 
   /**

--- a/src/views/LightView.ts
+++ b/src/views/LightView.ts
@@ -50,7 +50,7 @@ class LightView extends AbstractView {
    */
   #viewControllerCardConfig: cards.ControllerCardOptions = {
     title: "All Lights",
-    subtitle: Helper.getCountTemplate(LightView.#domain, "eq", "on") + " lights on",
+    subtitle: Helper.getCountTemplate(LightView.#domain, [{operator: "eq", value: "on"}]) + " lights on",
   };
 
   /**

--- a/src/views/SwitchView.ts
+++ b/src/views/SwitchView.ts
@@ -50,7 +50,7 @@ class SwitchView extends AbstractView {
    */
   #viewControllerCardConfig: cards.ControllerCardOptions = {
     title: "All Switches",
-    subtitle: Helper.getCountTemplate(SwitchView.#domain, "eq", "on") + " switches on",
+    subtitle: Helper.getCountTemplate(SwitchView.#domain, [{operator: "eq", value: "on"}]) + " switches on",
   };
 
   /**

--- a/src/views/VacuumView.ts
+++ b/src/views/VacuumView.ts
@@ -50,7 +50,7 @@ class VacuumView extends AbstractView {
    */
   #viewControllerCardConfig: cards.ControllerCardOptions = {
     title: "All Vacuums",
-    subtitle: Helper.getCountTemplate(VacuumView.#domain, "ne", "off") + " vacuums on",
+    subtitle: Helper.getCountTemplate(VacuumView.#domain, [{operator: "ne", value: "off"}]) + " vacuums on",
   };
 
   /**


### PR DESCRIPTION
- Adjusted the interface responsible for gathering entity counts from supporting a single filtering perspective, to zero or more perspectives (applied in series)
- Leveraging the above change, further enhanced the filtering of the climate chip/view to omit unavailable entities (when counting) .

Fixes #129