### PR TITLE
Add German translation

### DIFF
--- a/src/localize.ts
+++ b/src/localize.ts
@@ -1,11 +1,13 @@
 import {HomeAssistant} from "./types/homeassistant/types";
 import * as en from "./translations/en.json";
 import * as nl from "./translations/nl.json";
+import * as de from "./translations/de.json";
 
 /* Registry of currently supported languages */
 const languages: Record<string, unknown> = {
   en,
   nl,
+  de,
 };
 
 /* The fallback language if the user-defined language isn't defined */

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -44,6 +44,9 @@
   "media_player": {
     "media_players": "Wiedergabegeräte"
   },
+  "scene": {
+    "scenes": "Szenen"
+  },
   "select": {
     "selects": "Auswahlen"
   },

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -1,0 +1,62 @@
+{
+  "camera": {
+    "all_cameras": "Alle Kameras",
+    "cameras": "Kameras"
+  },
+  "climate": {
+    "all_climates": "Alle Klimaanlagen",
+    "climates": "Klimaanlagen"
+  },
+  "cover": {
+    "all_covers": "Alle Abdeckungen",
+    "covers": "Abdeckungen"
+  },
+  "fan": {
+    "all_fans": "Alle Ventilatoren",
+    "fans": "Ventilatoren"
+  },
+  "generic": {
+    "all": "Alle",
+    "areas": "Bereiche",
+    "busy": "Beschäftigt",
+    "good_afternoon": "Guten Nachmittag",
+    "good_evening": "Guten Abend",
+    "good_morning": "Guten Morgen",
+    "hello": "Hallo",
+    "home": "Start",
+    "miscellaneous": "Sonstiges",
+    "numbers": "Zahlen",
+    "off": "Aus",
+    "on": "Ein",
+    "open": "Offen",
+    "unclosed": "Nicht Geschlossen"
+  },
+  "input_select": {
+    "input_selects": "Auswahl-Eingaben"
+  },
+  "light": {
+    "all_lights": "Alle Leuchten",
+    "lights": "Leuchten"
+  },
+  "lock": {
+    "locks": "Schlösser"
+  },
+  "media_player": {
+    "media_players": "Wiedergabegeräte"
+  },
+  "select": {
+    "selects": "Auswahlen"
+  },
+  "sensor": {
+    "binary": "Binäre",
+    "sensors": "Sensoren"
+  },
+  "switch": {
+    "all_switches": "Alle Schalter",
+    "switches": "Schalter"
+  },
+  "vacuum": {
+    "all_vacuums": "Alle Staubsauger",
+    "vacuums": "Staubsauger"
+  }
+}


### PR DESCRIPTION
## Description

I have added a translations/de.json to support the German language in mushroom-strategy, imported the file into localize.ts and added de to the registry of supported languages. Closes #175 

## Type of Change

_Put an `x` in all boxes that apply_
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Hot fix (corrects a major software bug or fault and should released as quickly as possible.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [X] UI/UX improvement

## Testing

I have recompiled the mushroom-strategy.js and checked on my Home Assistant instance that the translations are applied.

## Impact

No effects other than the appearance of German translations in the elements generated by mushroom-strategy.

## Additional Information

![Exemplary screenshot of the headers for “Leuchten” and “Schalter.” Control elements for switching the groups off and on are located next to the titles.](https://github.com/user-attachments/assets/7c3cbe96-df1d-4b80-80aa-7f25ac7e86f2)

## Checklist

_Put an `x` in all boxes that apply_
- [X] My code adheres to the [coding and style guidelines](https://github.com/AalianKhan/mushroom-strategy/blob/main/CONTRIBUTING.md) of the project.
- [X] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
