### PR TITLE
Confirm chip action (Bump to v2.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ We welcome contributions and feedback!
 
 [hacsBadge]: https://img.shields.io/badge/HACS-Default-blue
 
-[releaseBadge]: https://img.shields.io/github/v/tag/digilive/mushroom-strategy?filter=v2.3.5&label=Release
+[releaseBadge]: https://img.shields.io/github/v/tag/digilive/mushroom-strategy?filter=v2.4.0&label=Release
 
 <!-- Repository References -->
 
-[releaseUrl]: https://github.com/DigiLive/mushroom-strategy/releases/tag/v2.3.5
+[releaseUrl]: https://github.com/DigiLive/mushroom-strategy/releases/tag/v2.4.0
 
 <!-- Other References -->
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,11 +68,11 @@ support helps us grow and improve.
 
 [hacsBadge]: https://img.shields.io/badge/HACS-Default-blue
 
-[releaseBadge]: https://img.shields.io/github/v/tag/digilive/mushroom-strategy?filter=v2.3.5&label=Release
+[releaseBadge]: https://img.shields.io/github/v/tag/digilive/mushroom-strategy?filter=v2.4.0&label=Release
 
 <!-- Repository References -->
 
-[releaseUrl]: https://github.com/DigiLive/mushroom-strategy/releases/tag/v2.3.5
+[releaseUrl]: https://github.com/DigiLive/mushroom-strategy/releases/tag/v2.4.0
 
 <!-- Other References -->
 

--- a/docs/options/home-view-options.md
+++ b/docs/options/home-view-options.md
@@ -61,14 +61,17 @@ home_view:
 ## Chip Options
 
 The mushroom strategy has chips that indicate the number of entities for a specific domain which are in an "active"
-state. Hidden/Disabled entities are excluded from this count.
+state.  
+Hidden/Disabled entities are excluded from this count.
 
-* Tapping a chip will set corresponding entities to an "inactive" state.[^1]
-* Tap and hold a chip, will navigate to the corresponding view.
+- Tapping a chip will set corresponding entities to an "inactive" state.[^1]  
+  _**Note:** The Switch chip requires a confirmation before executing its tap action to prevent accidental toggling of
+  all switches._
+- Holding a chip, will navigate to the corresponding view.
 
 [^1]: For some chips, the tap action is disabled.
 
-The `chips` group enables you to specify the configuration of chips.
+The `chips` group enables you to specify its configuration of chips.
 
 | Name             | type    | default | Description                                 |
 |:-----------------|:--------|:--------|:--------------------------------------------|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mushroom-strategy",
-  "version": "2.3.5",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mushroom-strategy",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mushroom-strategy",
-  "version": "2.3.5",
+  "version": "2.4.0",
   "description": "Automatically generate a dashboard of Mushroom cards.",
   "keywords": [
     "dashboard",

--- a/src/chips/SwitchChip.ts
+++ b/src/chips/SwitchChip.ts
@@ -4,6 +4,7 @@ import { Registry } from '../Registry';
 import { TemplateChipConfig } from '../types/lovelace-mushroom/utils/lovelace/chip/types';
 import AbstractChip from './AbstractChip';
 import RegistryFilter from '../utilities/RegistryFilter';
+import { localize } from '../utilities/localize';
 
 /**
  * Switch Chip class.
@@ -11,6 +12,17 @@ import RegistryFilter from '../utilities/RegistryFilter';
  * Used to create a chip configuration to indicate how many switches are on and to switch them all off.
  */
 class SwitchChip extends AbstractChip {
+  /**
+   * Class Constructor.
+   *
+   * @param {TemplateChipConfig} [customConfiguration] Custom chip configuration.
+   */
+  constructor(customConfiguration?: TemplateChipConfig) {
+    super();
+
+    this.configuration = { ...this.configuration, ...SwitchChip.getDefaultConfig(), ...customConfiguration };
+  }
+
   /** Returns the default configuration object for the chip. */
   static getDefaultConfig(): TemplateChipConfig {
     return {
@@ -20,6 +32,9 @@ class SwitchChip extends AbstractChip {
       content: Registry.getCountTemplate('switch', 'eq', 'on'),
       tap_action: {
         action: 'perform-action',
+        confirmation: {
+          text: localize('switch.chip_confirmation'),
+        },
         perform_action: 'switch.turn_off',
         target: {
           entity_id: new RegistryFilter(Registry.entities)
@@ -32,17 +47,6 @@ class SwitchChip extends AbstractChip {
         navigation_path: 'switches',
       },
     };
-  }
-
-  /**
-   * Class Constructor.
-   *
-   * @param {TemplateChipConfig} [customConfiguration] Custom chip configuration.
-   */
-  constructor(customConfiguration?: TemplateChipConfig) {
-    super();
-
-    this.configuration = { ...this.configuration, ...SwitchChip.getDefaultConfig(), ...customConfiguration };
   }
 }
 

--- a/src/mushroom-strategy.ts
+++ b/src/mushroom-strategy.ts
@@ -272,7 +272,7 @@ class MushroomStrategy extends HTMLTemplateElement {
 
 customElements.define('ll-strategy-mushroom-strategy', MushroomStrategy);
 
-const STRATEGY_VERSION = 'v2.3.5';
+const STRATEGY_VERSION = 'v2.4.0';
 console.info(
   '%c Mushroom Strategy %c '.concat(STRATEGY_VERSION, ' '),
   'color: white; background: coral; font-weight: 700;',

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -62,6 +62,7 @@
   },
   "switch": {
     "all_switches": "Alle Schalter",
+    "chip_confirmation": "Warnung: Diese Aktion wird alle Schalter ausschalten. Sind Sie sicher, dass Sie fortfahren möchten?",
     "switches": "Schalter"
   },
   "vacuum": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -62,6 +62,7 @@
   },
   "switch": {
     "all_switches": "All Switches",
+    "chip_confirmation": "Warning: This action will turn off all switches. Are you sure you want to continue?",
     "switches": "Switches"
   },
   "vacuum": {

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -62,6 +62,7 @@
   },
   "switch": {
     "all_switches": "Todos los Apagadores",
+    "chip_confirmation": "Advertencia: Esta acción apagará todos los interruptores. ¿Está seguro de que desea continuar?",
     "switches": "Apagadores"
   },
   "vacuum": {

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -62,6 +62,7 @@
   },
   "switch": {
     "all_switches": "Alle Schakelaars",
+    "chip_confirmation": "Waarschuwing: Deze actie zal alle schakelaars uitzetten. Weet u zeker dat u door wilt gaan?",
     "switches": "Schakelaars"
   },
   "vacuum": {

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -62,6 +62,7 @@
   },
   "switch": {
     "all_switches": "Todos os interruptores",
+    "chip_confirmation": "Atenção: Essa ação irá desligar todos os interruptores. Tem certeza que deseja continuar?",
     "switches": "Interruptores"
   },
   "vacuum": {


### PR DESCRIPTION
# Feature Pull Request

---

## Feature Summary

Add a confirmation dialog to the tap action of the Switch chip.

---

## Motivation and Context

Resolves #241.

Users can have switches which they do want to be included, but don't want them to switch off.
To prevent toggling those switches by accidentally tapping the chip, the tap action now must be confirmed.

---

## List of Changes

- The `tap_action` configuration of the Switch chip has been updated.
- Bumps the version to v2.4.0.

---

## Agreements

Please confirm the following by inserting an `x` between the brackets:

- [x] My code adheres to the [contribution guidelines](blob/main/CONTRIBUTING.md) of the project.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
