### PR TITLE
Fix: Wrong localization key for the title in LockView

### DIFF
--- a/src/views/LockView.ts
+++ b/src/views/LockView.ts
@@ -18,7 +18,7 @@ class LockView extends AbstractView {
   /** Returns the default configuration object for the view. */
   static getDefaultConfig(): ViewConfig {
     return {
-      title: localize('locks.locks'),
+      title: localize('lock.locks'),
       path: 'locks',
       icon: 'mdi:lock-open',
       subview: false,


### PR DESCRIPTION
# Bug Fix Pull Request

Thank you for contributing to the project by fixing this bug!  
Please fill out the following information to help us review your pull request.

---

## Bug Summary

Fixes #302 

---

## List of Changes

Corrected the localization key for the title in LockView.

The fix is implemented in the build below and can be tested by following the [Local Installation](https://digilive.github.io/mushroom-strategy/latest/getting-started/installation/#local-installation) instructions, starting from step 2.

[mushroom-strategy.js](https://github.com/user-attachments/files/26309829/mushroom-strategy.js)




