### PR TITLE
Domain View - Area Header Card does not switch all entities

### DIFF
--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -2,7 +2,13 @@ import deepmerge from 'deepmerge';
 import { HassEntities } from 'home-assistant-js-websocket';
 import { DeviceRegistryEntry } from './types/homeassistant/data/device_registry';
 import { EntityRegistryEntry } from './types/homeassistant/data/entity_registry';
-import { DashboardInfo, StrategyConfig, SupportedDomains, StrategyArea } from './types/strategy/strategy-generics';
+import {
+  DashboardInfo,
+  StrategyConfig,
+  SupportedDomains,
+  StrategyArea,
+  isSupportedDomain,
+} from './types/strategy/strategy-generics';
 import { logMessage, lvlFatal, lvlOff, lvlWarn, setDebugLevel } from './utilities/debug';
 import setupCustomLocalize, { localize } from './utilities/localize';
 import RegistryFilter from './utilities/RegistryFilter';
@@ -138,6 +144,22 @@ class Registry {
     Registry._entities = new RegistryFilter(Registry.entities)
       .isNotHidden()
       .whereDisabledBy(null)
+      .where((entity) => {
+        // Filter out config and diagnostic entities if the domain has hide_config_entities or hide_diagnostic_entities enabled.
+        const entityDomain = entity.entity_id.split('.', 1)[0];
+        const domain = isSupportedDomain(entityDomain) ? entityDomain : 'default';
+
+        const domainOptions = {
+          ...Registry.strategyOptions.domains['_'],
+          ...Registry.strategyOptions.domains[domain],
+        };
+
+        if (domainOptions.hide_config_entities && entity.entity_category === 'config') {
+          return false;
+        }
+
+        return !(domainOptions.hide_diagnostic_entities && entity.entity_category === 'diagnostic');
+      })
       .toList()
       .map((entity) => ({ ...entity, area_id: entity.area_id ?? 'undisclosed' }));
 

--- a/src/cards/HeaderCard.ts
+++ b/src/cards/HeaderCard.ts
@@ -68,8 +68,8 @@ class HeaderCard {
             layout: 'vertical',
             icon_color: 'red',
             tap_action: {
-              action: 'call-service',
-              service: this.configuration.offService,
+              action: 'perform-action',
+              perform_action: this.configuration.offService,
               target: this.target,
               data: {},
             },
@@ -80,8 +80,8 @@ class HeaderCard {
             layout: 'vertical',
             icon_color: 'amber',
             tap_action: {
-              action: 'call-service',
-              service: this.configuration.onService,
+              action: 'perform-action',
+              perform_action: this.configuration.onService,
               target: this.target,
               data: {},
             },

--- a/src/mushroom-strategy.ts
+++ b/src/mushroom-strategy.ts
@@ -150,8 +150,6 @@ class MushroomStrategy extends HTMLTemplateElement {
 
       const entities = new RegistryFilter(areaEntities)
         .whereDomain(domain)
-        .when(domainOptions.hide_config_entities, (filter) => filter.not().whereEntityCategory('config'))
-        .when(domainOptions.hide_diagnostic_entities, (filter) => filter.not().whereEntityCategory('diagnostic'))
         .where((entity) => !(domain === 'switch' && entity.entity_id.endsWith('_stateful_scene')))
         .toList();
 

--- a/src/views/AbstractView.ts
+++ b/src/views/AbstractView.ts
@@ -101,17 +101,10 @@ abstract class AbstractView {
 
       let areaCards: AbstractCardConfig[] = [];
 
-      // Set the target of the Header card to the current area.
-      let target: HassServiceTarget = {
-        area_id: [area.area_id],
+      // Set the target of the Header card to entities.
+      const target = {
+        entity_id: areaEntities.map((entity) => entity.entity_id),
       };
-
-      // Set the target of the Header card to entities without an area.
-      if (area.area_id === 'undisclosed') {
-        target = {
-          entity_id: areaEntities.map((entity) => entity.entity_id),
-        };
-      }
 
       // Create a card configuration for each entity in the current area.
       areaCards.push(


### PR DESCRIPTION
# Bug Fix Pull Request

## Bug Summary

Clicking the On/Off buttons of the _Area Header_ cards in a _Domain_ view do not switch _configuration_ and _diagnostic_ entities.

Resolves #331 

---

## List of Changes

* Filtering of _configuration_ and _diagnostic_ entities moved from `MushroomStrategy::generateView()` to `Registry::Initialize()` so their presence is consistent in all views.
* Refactor `tap_action` of the On/Off buttons of the _Header_ card to use `perform_action` instead of `call-service`.
* Removed the `area_id` target from the _Header_ card in favor of target `entity_id` so entities of the 'undisclosed' area are not excluded.

- ...

## Steps to Reproduce (if not covered in the linked issue)

1. Click the On or Off button at an _Area Header_ card in a Domain view.

## Expected Behavior (if not covered in the linked issue)

All entities (present in the view) of the regarding area should be switched.

### Actual Behavior (if not covered in the linked issue)

_Configuration_ and _diagnostic_ entities do **NOT** switch.

---

## Agreements

Please confirm the following by inserting an `x` between the brackets:

- [x] My code adheres to the [contribution guidelines](blob/main/CONTRIBUTING.md) of the project.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
